### PR TITLE
fix: Replace quarkus-smallrye-reactive-messaging-kafka with quarkus-messaging-kafka

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,7 @@
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-smallrye-reactive-messaging-kafka</artifactId>
-      <version>3.15.7</version>
+      <artifactId>quarkus-messaging-kafka</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kie</groupId>


### PR DESCRIPTION
This commit replaces quarkus-smallrye-reactive-messaging-kafka with
quarkus-messaging-kafka due to quarkus-smallrye-reactive-messaging-kafka
naming beeing deprecated in quarkus 3.9.